### PR TITLE
Expose digest type for HMAC generation

### DIFF
--- a/ArcaneTests/Tests.swift
+++ b/ArcaneTests/Tests.swift
@@ -54,6 +54,15 @@ class Tests: XCTestCase {
     XCTAssertEqual(HMAC.SHA384(string, key: key), "afa2026322d2843e564a9d88e2a03a5a4f75581386217052d952bdda7a7af6a48ba4e0b927229cdec46cdf7e5ffa9ee3")
     XCTAssertEqual(HMAC.SHA512(string, key: key), "d75af2a8f76dd22b3e7a52f84593e3c9d56065a675f5e96ecf3e1354d6dba05f357418fbfbd3af0491e69f548bb4200600d139d601741c6c9eb37952e2e38d7a")
   }
+    
+  func testHMACWithDigest() {
+    XCTAssertEqual(HMAC.MD5(string, key: key, digest: .base64), "QZM3+Nougc3xLcubjkzXbA==")
+    XCTAssertEqual(HMAC.SHA1(string, key: key, digest: .base64), "X0R0yIctc8FJAkGrAV9sZyxtzcg=")
+    XCTAssertEqual(HMAC.SHA224(string, key: key, digest: .base64), "gqkD+qT5PFKPSQxpnJv+8MDvijSY3Wd8+rCnHg==")
+    XCTAssertEqual(HMAC.SHA256(string, key: key, digest: .base64), "qOMUvwAcXqZAw3RYL1on2dKaOcsbHHKXSLrVNl37BjI=")
+    XCTAssertEqual(HMAC.SHA384(string, key: key, digest: .base64), "r6ICYyLShD5WSp2I4qA6Wk91WBOGIXBS2VK92np69qSLpOC5JyKc3sRs335f+p7j")
+    XCTAssertEqual(HMAC.SHA512(string, key: key, digest: .base64), "11ryqPdt0is+elL4RZPjydVgZaZ19eluzz4TVNbboF81dBj7+9OvBJHmn1SLtCAGANE51gF0HGyes3lS4uONeg==")
+  }
 
   func testObfuscator() {
     let obfuscator = Obfuscator(value: "").a.b.c.d.e.n1.n2.X.Y.Z

--- a/Sources/HMAC.swift
+++ b/Sources/HMAC.swift
@@ -11,6 +11,11 @@ import CCommonCrypto
 
 public struct HMAC {
 
+  public enum DigestType {
+    case hex
+    case base64
+  }
+
   // MARK: - NSData
 
   public static func MD5(_ data: Data, key: Data) -> Data? {
@@ -49,35 +54,36 @@ public struct HMAC {
 
   // MARK: - String
 
-  public static func MD5(_ string: String, key: String) -> String? {
-    return HMAC.generate(string, key: key, crypto: .MD5)
+  public static func MD5(_ string: String, key: String, digest: DigestType = .hex) -> String? {
+    return HMAC.generate(string, key: key, crypto: .MD5, digest: digest)
   }
 
-  public static func SHA1(_ string: String, key: String) -> String? {
-    return HMAC.generate(string, key: key, crypto: .SHA1)
+  public static func SHA1(_ string: String, key: String, digest: DigestType = .hex) -> String? {
+    return HMAC.generate(string, key: key, crypto: .SHA1, digest: digest)
   }
 
-  public static func SHA224(_ string: String, key: String) -> String? {
-    return HMAC.generate(string, key: key, crypto: .SHA224)
+  public static func SHA224(_ string: String, key: String, digest: DigestType = .hex) -> String? {
+    return HMAC.generate(string, key: key, crypto: .SHA224, digest: digest)
   }
 
-  public static func SHA256(_ string: String, key: String) -> String? {
-    return HMAC.generate(string, key: key, crypto: .SHA256)
+  public static func SHA256(_ string: String, key: String, digest: DigestType = .hex) -> String? {
+    return HMAC.generate(string, key: key, crypto: .SHA256, digest: digest)
   }
 
-  public static func SHA384(_ string: String, key: String) -> String? {
-    return HMAC.generate(string, key: key, crypto: .SHA384)
+  public static func SHA384(_ string: String, key: String, digest: DigestType = .hex) -> String? {
+    return HMAC.generate(string, key: key, crypto: .SHA384, digest: digest)
   }
 
-  public static func SHA512(_ string: String, key: String) -> String? {
-    return HMAC.generate(string, key: key, crypto: .SHA512)
+  public static func SHA512(_ string: String, key: String, digest: DigestType = .hex) -> String? {
+    return HMAC.generate(string, key: key, crypto: .SHA512, digest: digest)
   }
 
-  static func generate(_ string: String, key: String, crypto: Crypto) -> String? {
+  static func generate(_ string: String, key: String, crypto: Crypto, digest: DigestType) -> String? {
     guard let data = string.data(using: String.Encoding.utf8),
-      let keyData = key.data(using: String.Encoding.utf8)
+      let keyData = key.data(using: String.Encoding.utf8),
+      let generatedData = HMAC.generate(data, key: keyData, crypto: crypto)
       else { return nil }
 
-    return HMAC.generate(data, key: keyData, crypto: crypto)?.hexString
+    return digest == .hex ? generatedData.hexString : generatedData.base64String
   }
 }


### PR DESCRIPTION
I needed the `base64` digest result of an `HMAC` encryption so I can generate `JWT` tokens (http://jwt.io), but `Arcane` was hard-coded to `hex`.

This PR exposes the option to choose `hex` or `base64` digest for `HMAC` results:
```
HMAC.SHA256(string, key: key, digest: .hex) //Default
HMAC.SHA256(string, key: key, digest: .base64)
```
See how [other languages](https://github.com/danharper/hmac-examples) natively expose this option and some [online encryption results](https://hash.online-convert.com/sha256-generator) that returns both digests.

With this new `DigestType` enum, maybe you can delete `Base64` and use this API instead:
```
Hash.SHA256(string, key: key, digest: .hex) //Default
Hash.SHA256(string, key: key, digest: .base64)
```
I hope this helps and makes sense. Thanks for a great library! 👍 