### PR TITLE
Fix test info plist paths

### DIFF
--- a/Arcane.xcodeproj/project.pbxproj
+++ b/Arcane.xcodeproj/project.pbxproj
@@ -773,7 +773,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "$(SRCROOT)/Tests/ArcaneTests/Info-iOS.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/Tests/ArcaneTests/Info-tvOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fantageek.Arcane-tvOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -794,7 +794,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "$(SRCROOT)/Tests/ArcaneTests/Info-iOS.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/Tests/ArcaneTests/Info-tvOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fantageek.Arcane-tvOS-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1037,7 +1037,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = "$(SRCROOT)/Tests/ArcaneTests/Info-iOS.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/Tests/ArcaneTests/Info-macOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.CommonCryptoSwift-MacTests";
@@ -1052,7 +1052,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
-				INFOPLIST_FILE = "$(SRCROOT)/Tests/ArcaneTests/Info-iOS.plist";
+				INFOPLIST_FILE = "$(SRCROOT)/Tests/ArcaneTests/Info-macOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "no.hyper.CommonCryptoSwift-MacTests";


### PR DESCRIPTION
Seems in my haste in #23 I didn't assign the correct info plists for the test targets. However the plists seem to be functionally duplicates so the tests still pass as is.
This PR corrects the paths for correctness/completeness